### PR TITLE
fix(stream): close realtime sessions when __aenter__ fails

### DIFF
--- a/gradium/stream.py
+++ b/gradium/stream.py
@@ -162,14 +162,19 @@ class Tts:
 
     async def __aenter__(self):
         self._session = aiohttp.ClientSession(headers=self._client.headers)
-        self._ws = await self._client.ws(self._session, self._route)
-        if self._send_setup_on_start:
-            await self.send_setup(self._kwargs)
-            ready = await self.wait_for_ready()
-            self._ready = ready
-        else:
-            self._ready = None
-        return self
+        try:
+            self._ws = await self._client.ws(self._session, self._route)
+            if self._send_setup_on_start:
+                await self.send_setup(self._kwargs)
+                ready = await self.wait_for_ready()
+                self._ready = ready
+            else:
+                self._ready = None
+            return self
+        except Exception:
+            # __aexit__ is not automatically called when __aenter__ raises.
+            await self.__aexit__(None, None, None)
+            raise
 
     async def __aexit__(self, exc_type, exc, tb):
         if self._ws is not None:
@@ -393,11 +398,16 @@ class Stt:
 
     async def __aenter__(self):
         self._session = aiohttp.ClientSession(headers=self._client.headers)
-        self._ws = await self._client.ws(self._session, self._route)
-        await self.send_setup(self._kwargs)
-        ready = await self.wait_for_ready()
-        self._ready = ready
-        return self
+        try:
+            self._ws = await self._client.ws(self._session, self._route)
+            await self.send_setup(self._kwargs)
+            ready = await self.wait_for_ready()
+            self._ready = ready
+            return self
+        except Exception:
+            # __aexit__ is not automatically called when __aenter__ raises.
+            await self.__aexit__(None, None, None)
+            raise
 
     async def __aexit__(self, exc_type, exc, tb):
         if self._ws is not None:


### PR DESCRIPTION
## Summary
This fixes a resource leak in realtime streaming context managers (`Tts`, `Stt`) when initialization fails during `__aenter__`.

When setup/ready handshake raises, Python does not automatically call `__aexit__`, so `aiohttp.ClientSession` can remain open and emit:  `Unclosed client session`

  ## Root cause
  Both `Tts.__aenter__` and `Stt.__aenter__`:
  1. create `ClientSession`
  2. perform websocket/setup/ready steps that may raise
  3. rely on `__aexit__` for cleanup

  If step 2 raises before `__aenter__` returns, cleanup is skipped.

  ## Changes
  - Wrapped `Tts.__aenter__` logic in `try/except`.
  - Wrapped `Stt.__aenter__` logic in `try/except`.
  - On failure, explicitly call `await self.__aexit__(None, None, None)` before re-raising.
  - Added an inline comment explaining why this is needed:
    - `__aexit__` is not automatically called when `__aenter__` raises.