### PR TITLE
Update docs and examples to use unified api.gradium.ai endpoint

### DIFF
--- a/docs/post_tts_description.md
+++ b/docs/post_tts_description.md
@@ -5,14 +5,8 @@ data is sent back in a streaming way.
 
 **Endpoint URL:**
 
-For Europe
 ```
-https://eu.api.gradium.ai/api/post/speech/tts
-```
-
-For the USA
-```
-https://us.api.gradium.ai/api/post/speech/tts
+https://api.gradium.ai/api/post/speech/tts
 ```
 
 **Authentication:**
@@ -24,7 +18,7 @@ Include your API key in the request header:
 ## Quick Example
 
 ```bash
-curl -L -X POST https://eu.api.gradium.ai/api/post/speech/tts \
+curl -L -X POST https://api.gradium.ai/api/post/speech/tts \
   -H "x-api-key: your_api_key" \
   -H "Content-Type: application/json" \
   -d '{"text": "Hello, this is a test of the text to speech system.", "voice_id": "YTpq7expH9539ERJ", "output_format": "wav", "only_audio": true}' \

--- a/docs/websocket_stt_description.md
+++ b/docs/websocket_stt_description.md
@@ -4,14 +4,8 @@ Connect to this endpoint via WebSocket for real-time speech-to-text conversion w
 
 **Connection URL:**
 
-For Europe
 ```
-wss://eu.api.gradium.ai/api/speech/asr
-```
-
-For the USA
-```
-wss://us.api.gradium.ai/api/speech/asr
+wss://api.gradium.ai/api/speech/asr
 ```
 
 **Authentication:**

--- a/docs/websocket_tts_description.md
+++ b/docs/websocket_tts_description.md
@@ -4,14 +4,8 @@ Connect to this endpoint via WebSocket for real-time text-to-speech conversion w
 
 **Connection URL:**
 
-For Europe
 ```
-wss://eu.api.gradium.ai/api/speech/tts
-```
-
-For the USA
-```
-wss://us.api.gradium.ai/api/speech/tts
+wss://api.gradium.ai/api/speech/tts
 ```
 
 

--- a/examples/stt_streaming.py
+++ b/examples/stt_streaming.py
@@ -12,7 +12,7 @@ async def main():
     parser = argparse.ArgumentParser(description="Test STT WebSocket API")
     parser.add_argument(
         "--url",
-        default="https://eu.api.gradium.ai/api",
+        default="https://api.gradium.ai/api",
     )
     parser.add_argument(
         "--api-key", required=True, help="API key for authentication"

--- a/examples/temp_token.py
+++ b/examples/temp_token.py
@@ -32,7 +32,7 @@ async def synthesize_speech(uri: str, api_key: str, text: str):
     Synthesize speech using temporary token authentication.
 
     Args:
-        uri: Base API URI (e.g., https://eu.api.gradium.ai/api)
+        uri: Base API URI (e.g., https://api.gradium.ai/api)
         api_key: API key for authentication
         text: Text to synthesize
     """
@@ -110,8 +110,8 @@ def main():
     )
     parser.add_argument(
         "--uri",
-        default="https://eu.api.gradium.ai/api",
-        help="Base API URI (default: https://eu.api.gradium.ai/api)",
+        default="https://api.gradium.ai/api",
+        help="Base API URI (default: https://api.gradium.ai/api)",
     )
     parser.add_argument(
         "--api-key",

--- a/examples/tts_streaming.py
+++ b/examples/tts_streaming.py
@@ -15,7 +15,7 @@ This is a test of the text to speech streaming capabilities of the Gradium API.
 
 async def main():
     parser = argparse.ArgumentParser(description="Test TTS WebSocket API")
-    parser.add_argument("--url", default="https://eu.api.gradium.ai/api")
+    parser.add_argument("--url", default="https://api.gradium.ai/api")
     parser.add_argument("--api-key", help="API key for authentication")
     parser.add_argument(
         "--text", help="Text to synthesize", default=DEFAULT_TEXT

--- a/gradium/cli.py
+++ b/gradium/cli.py
@@ -156,7 +156,7 @@ def main() -> int:
     )
     tts_parser.add_argument(
         "--gradium-base-url",
-        default="https://eu.api.gradium.ai/api",
+        default="https://api.gradium.ai/api",
         help="Gradium API base URL",
     )
     tts_parser.add_argument(
@@ -178,7 +178,7 @@ def main() -> int:
     )
     stt_parser.add_argument(
         "--gradium-base-url",
-        default="https://eu.api.gradium.ai/api",
+        default="https://api.gradium.ai/api",
         help="Gradium API base URL",
     )
     stt_parser.add_argument(

--- a/notebooks/gradium_example_eu.ipynb
+++ b/notebooks/gradium_example_eu.ipynb
@@ -85,7 +85,7 @@
       "cell_type": "code",
       "source": [
         "from gradium import GradiumClient\n",
-        "client = GradiumClient(base_url='eu.api.gradium.ai/api')"
+        "client = GradiumClient(base_url='api.gradium.ai/api')"
       ],
       "metadata": {
         "id": "RMAsYgPfSa1X"
@@ -158,7 +158,7 @@
       "source": [
         "audio = await client.tts(\n",
         "    setup={'voice_id': 'axlOaUiFyOZhy4nv', 'output_format': 'wav'},\n",
-        "    text='Bonjour, ceci est un test du système de synthèse vocale de Gradium. Merci de bien vouloir respecter la consigne.'\n",
+        "    text='Bonjour, ceci est un test du syst\u00e8me de synth\u00e8se vocale de Gradium. Merci de bien vouloir respecter la consigne.'\n",
         ")\n",
         "\n",
         "display.display(display.Audio(audio.raw_data))"
@@ -281,11 +281,11 @@
             "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... connected.\n",
             "HTTP request sent, awaiting response... 200 OK\n",
             "Length: 759450 (742K) [audio/mpeg]\n",
-            "Saving to: ‘sample.mp3’\n",
+            "Saving to: \u2018sample.mp3\u2019\n",
             "\n",
             "sample.mp3          100%[===================>] 741.65K  --.-KB/s    in 0.04s   \n",
             "\n",
-            "2025-12-09 10:50:32 (16.7 MB/s) - ‘sample.mp3’ saved [759450/759450]\n",
+            "2025-12-09 10:50:32 (16.7 MB/s) - \u2018sample.mp3\u2019 saved [759450/759450]\n",
             "\n"
           ]
         },
@@ -785,7 +785,7 @@
             "Collecting sphn\n",
             "  Downloading sphn-0.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.6 kB)\n",
             "Downloading sphn-0.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (17.4 MB)\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m17.4/17.4 MB\u001b[0m \u001b[31m75.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u001b[0m \u001b[32m17.4/17.4 MB\u001b[0m \u001b[31m75.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
             "\u001b[?25hInstalling collected packages: sphn\n",
             "Successfully installed sphn-0.2.0\n",
             "--2025-12-09 10:51:13--  https://github.com/kyutai-labs/delayed-streams-modeling/raw/refs/heads/main/audio/bria.mp3\n",
@@ -798,11 +798,11 @@
             "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... connected.\n",
             "HTTP request sent, awaiting response... 200 OK\n",
             "Length: 717635 (701K) [audio/mpeg]\n",
-            "Saving to: ‘bria.mp3’\n",
+            "Saving to: \u2018bria.mp3\u2019\n",
             "\n",
             "bria.mp3            100%[===================>] 700.82K  --.-KB/s    in 0.04s   \n",
             "\n",
-            "2025-12-09 10:51:13 (15.3 MB/s) - ‘bria.mp3’ saved [717635/717635]\n",
+            "2025-12-09 10:51:13 (15.3 MB/s) - \u2018bria.mp3\u2019 saved [717635/717635]\n",
             "\n"
           ]
         }

--- a/notebooks/gradium_example_us.ipynb
+++ b/notebooks/gradium_example_us.ipynb
@@ -85,7 +85,7 @@
       "cell_type": "code",
       "source": [
         "from gradium import GradiumClient\n",
-        "client = GradiumClient(base_url='us.api.gradium.ai/api')"
+        "client = GradiumClient(base_url='api.gradium.ai/api')"
       ],
       "metadata": {
         "id": "RMAsYgPfSa1X"
@@ -158,7 +158,7 @@
       "source": [
         "audio = await client.tts(\n",
         "    setup={'voice_id': 'axlOaUiFyOZhy4nv', 'output_format': 'wav'},\n",
-        "    text='Bonjour, ceci est un test du système de synthèse vocale de Gradium. Merci de bien vouloir respecter la consigne.'\n",
+        "    text='Bonjour, ceci est un test du syst\u00e8me de synth\u00e8se vocale de Gradium. Merci de bien vouloir respecter la consigne.'\n",
         ")\n",
         "\n",
         "display.display(display.Audio(audio.raw_data))"
@@ -281,11 +281,11 @@
             "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... connected.\n",
             "HTTP request sent, awaiting response... 200 OK\n",
             "Length: 759450 (742K) [audio/mpeg]\n",
-            "Saving to: ‘sample.mp3’\n",
+            "Saving to: \u2018sample.mp3\u2019\n",
             "\n",
             "sample.mp3          100%[===================>] 741.65K  --.-KB/s    in 0.04s   \n",
             "\n",
-            "2025-12-09 10:50:32 (16.7 MB/s) - ‘sample.mp3’ saved [759450/759450]\n",
+            "2025-12-09 10:50:32 (16.7 MB/s) - \u2018sample.mp3\u2019 saved [759450/759450]\n",
             "\n"
           ]
         },
@@ -785,7 +785,7 @@
             "Collecting sphn\n",
             "  Downloading sphn-0.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.6 kB)\n",
             "Downloading sphn-0.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (17.4 MB)\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m17.4/17.4 MB\u001b[0m \u001b[31m75.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u001b[0m \u001b[32m17.4/17.4 MB\u001b[0m \u001b[31m75.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
             "\u001b[?25hInstalling collected packages: sphn\n",
             "Successfully installed sphn-0.2.0\n",
             "--2025-12-09 10:51:13--  https://github.com/kyutai-labs/delayed-streams-modeling/raw/refs/heads/main/audio/bria.mp3\n",
@@ -798,11 +798,11 @@
             "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... connected.\n",
             "HTTP request sent, awaiting response... 200 OK\n",
             "Length: 717635 (701K) [audio/mpeg]\n",
-            "Saving to: ‘bria.mp3’\n",
+            "Saving to: \u2018bria.mp3\u2019\n",
             "\n",
             "bria.mp3            100%[===================>] 700.82K  --.-KB/s    in 0.04s   \n",
             "\n",
-            "2025-12-09 10:51:13 (15.3 MB/s) - ‘bria.mp3’ saved [717635/717635]\n",
+            "2025-12-09 10:51:13 (15.3 MB/s) - \u2018bria.mp3\u2019 saved [717635/717635]\n",
             "\n"
           ]
         }


### PR DESCRIPTION
## Summary
- Replace all remaining references to regional endpoints (`eu.api.gradium.ai` and `us.api.gradium.ai`) with the new unified endpoint (`api.gradium.ai`)
- Removes the EU/US split from docs, examples, CLI defaults, and notebooks (9 files)

## Test plan
- [ ] Verify docs render correctly with the new single endpoint
- [ ] Spot-check CLI defaults (`gradium tts --help`, `gradium stt --help`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)